### PR TITLE
Change case to Cordova

### DIFF
--- a/src/ios/LaunchNavigator.h
+++ b/src/ios/LaunchNavigator.h
@@ -27,9 +27,9 @@
  *
  */
 #ifdef CORDOVA_FRAMEWORK
-#import <CORDOVA/CDVPlugin.h>
+#import <Cordova/CDVPlugin.h>
 #else
-#import "CORDOVA/CDVPlugin.h"
+#import "Cordova/CDVPlugin.h"
 #endif
 
 #import <MapKit/MapKit.h>


### PR DESCRIPTION
Having the lowercase "CORDOVA" causes a build error when using this plugin:

platforms/ios/CarnetJove/Plugins/uk.co.workingedge.phonegap.plugin.LaunchNavigator/LaunchNavigator.h:32:9: fatal error: 'CORDOVA/CDVPlugin.h' file not found
#import "CORDOVA/CDVPlugin.h"
        ^
1 error generated.

This commit fixes it