### PR TITLE
syntax fixes

### DIFF
--- a/uk.co.workingedge.phonegap.plugin.launchnavigator.d.ts
+++ b/uk.co.workingedge.phonegap.plugin.launchnavigator.d.ts
@@ -401,7 +401,7 @@ interface LaunchNavigator {
 
     /**
      * Triggers the native dialog picker for user to choose wich app to use.
-     * @param {mixed} destination (required) - destination location to use for navigation - see launchnavigator.navigate()
+     * @param {string/number[]} destination (required) - destination location to use for navigation - see launchnavigator.navigate()
      * @param {object} options (optional) - optional parameters - see launchnavigator.navigate()
      * @param {Function} successCallback (optional) - optional callback to be invoked on success
      * @param {Function} errorCallback (optional) - optional callback to be invoked on error

--- a/www/android/launchnavigator.js
+++ b/www/android/launchnavigator.js
@@ -91,7 +91,7 @@ ln.isAppAvailable = function(appName, success, error){
  * Opens navigator app to navigate to given destination, specified by either place name or lat/lon.
  * If a start location is not also specified, current location will be used for the start.
  *
- * @param {mixed} destination (required) - destination location to use for navigation.
+ * @param {string/number[]} destination (required) - destination location to use for navigation.
  * Either:
  * - a {string} containing the address. e.g. "Buckingham Palace, London"
  * - an {array}, where the first element is the latitude and the second element is a longitude, as decimal numbers. e.g. [50.1, -4.0]
@@ -165,20 +165,20 @@ ln.navigate = function(destination, options) {
     options.enableGeocoding = typeof options.enableGeocoding !== "undefined" ? options.enableGeocoding : true;
 
     // If app is user-selection
-    if(options.app == common.APP.USER_SELECT){
+    if(options.app === common.APP.USER_SELECT){
         // Invoke user-selection UI and return (as it will re-invoke this method)
         return common.userSelect(destination, options);
     }
 
     destination = common.util.extractCoordsFromLocationString(destination);
-    if(typeof(destination) == "object"){
+    if(typeof(destination) === "object"){
         dType = "pos";
     }else{
         dType = "name";
     }
     if(options.start){
         options.start = common.util.extractCoordsFromLocationString(options.start);
-        if(typeof(options.start) == "object"){
+        if(typeof(options.start) === "object"){
             sType = "pos";
         }else{
             sType = "name";
@@ -240,7 +240,7 @@ ln.supportsTransportMode = function(app, platform, launchMode){
     common.util.validatePlatform(platform);
 
     var result;
-    if(launchMode && platform == common.PLATFORM.ANDROID && app == common.APP.GOOGLE_MAPS){
+    if(launchMode && platform === common.PLATFORM.ANDROID && app === common.APP.GOOGLE_MAPS){
         common.util.validateLaunchMode(launchMode);
         result = launchMode === ln.LAUNCH_MODE.TURN_BY_TURN;
     }else{
@@ -255,7 +255,7 @@ common._supportsTransportMode = common.supportsTransportMode;
  * @param {string} app - specified as a constant in `launchnavigator.APP`. e.g. `launchnavigator.APP.GOOGLE_MAPS`.
  * @param {string} platform - specified as a constant in `launchnavigator.PLATFORM`. e.g. `launchnavigator.PLATFORM.IOS`.
  * @param {string} launchMode (optional) - only applies to Google Maps on Android. Specified as a constant in `launchnavigator.LAUNCH_MODE`. e.g. `launchnavigator.LAUNCH_MODE.MAPS`.
- * @return {array} - list of transports modes as constants in `launchnavigator.TRANSPORT_MODE`.
+ * @return {string[]} - list of transports modes as constants in `launchnavigator.TRANSPORT_MODE`.
  * If app/platform combination doesn't support specification of transport mode, the list will be empty;
  */
 ln.getTransportModes = function(app, platform, launchMode){
@@ -277,7 +277,7 @@ ln.supportsStart = function(app, platform, launchMode){
     common.util.validatePlatform(platform);
 
     var result;
-    if(launchMode && platform == common.PLATFORM.ANDROID && app == common.APP.GOOGLE_MAPS){
+    if(launchMode && platform === common.PLATFORM.ANDROID && app === common.APP.GOOGLE_MAPS){
         common.util.validateLaunchMode(launchMode);
         result = launchMode === ln.LAUNCH_MODE.MAPS;
     }else{
@@ -297,7 +297,7 @@ common._supportsStart = common.supportsStart;
 ln.supportsDestName = function(app, platform, launchMode){
     common.util.validateApp(app);
     common.util.validatePlatform(platform);
-    if(launchMode && platform == common.PLATFORM.ANDROID && app == common.APP.GOOGLE_MAPS){
+    if(launchMode && platform === common.PLATFORM.ANDROID && app === common.APP.GOOGLE_MAPS){
         common.util.validateLaunchMode(launchMode);
         result = launchMode === ln.LAUNCH_MODE.GEO;
     }else{

--- a/www/common.js
+++ b/www/common.js
@@ -267,7 +267,7 @@ ln.TRANSPORT_MODES[ln.PLATFORM.IOS][ln.APP.MAPS_ME] = [
 
 /**
  * Apps by platform that support specifying a start location
- * @type {obect}
+ * @type {object}
  */
 ln.SUPPORTS_START = {};
 ln.SUPPORTS_START[ln.PLATFORM.ANDROID] = [
@@ -300,7 +300,7 @@ ln.SUPPORTS_START[ln.PLATFORM.WINDOWS] = [
 
 /**
  * Apps by platform that support specifying a start nickname
- * @type {obect}
+ * @type {object}
  */
 ln.SUPPORTS_START_NAME = {};
 ln.SUPPORTS_START_NAME[ln.PLATFORM.ANDROID] = [
@@ -321,7 +321,7 @@ ln.SUPPORTS_START_NAME[ln.PLATFORM.IOS] = [
 
 /**
  * Apps by platform that support specifying a destination nickname
- * @type {obect}
+ * @type {object}
  */
 ln.SUPPORTS_DEST_NAME = {};
 ln.SUPPORTS_DEST_NAME[ln.PLATFORM.ANDROID] = [
@@ -345,7 +345,7 @@ ln.SUPPORTS_DEST_NAME[ln.PLATFORM.IOS] = [
 
 /**
  * Apps by platform that support specifying a launch mode
- * @type {obect}
+ * @type {object}
  */
 ln.SUPPORTS_LAUNCH_MODE = {};
 ln.SUPPORTS_LAUNCH_MODE[ln.PLATFORM.ANDROID] = [
@@ -378,7 +378,7 @@ ln.getAppDisplayName = function(app){
 /**
  * Returns list of supported apps on a given platform.
  * @param {string} platform - specified as a constant in `launchnavigator.PLATFORM`. e.g. `launchnavigator.PLATFORM.IOS`.
- * @return {array} - apps supported on specified platform as a list of `launchnavigator.APP` constants.
+ * @return {string[]} - apps supported on specified platform as a list of `launchnavigator.APP` constants.
  */
 ln.getAppsForPlatform = function(platform){
     ln.util.validatePlatform(platform);
@@ -401,7 +401,7 @@ ln.supportsTransportMode = function(app, platform){
  * Returns the list of transport modes supported by an app on a given platform.
  * @param {string} app - specified as a constant in `launchnavigator.APP`. e.g. `launchnavigator.APP.GOOGLE_MAPS`.
  * @param {string} platform - specified as a constant in `launchnavigator.PLATFORM`. e.g. `launchnavigator.PLATFORM.IOS`.
- * @return {array} - list of transports modes as constants in `launchnavigator.TRANSPORT_MODE`.
+ * @return {string[]} - list of transports modes as constants in `launchnavigator.TRANSPORT_MODE`.
  * If app/platform combination doesn't support specification of transport mode, the list will be empty;
  */
 ln.getTransportModes = function(app, platform){
@@ -462,8 +462,10 @@ ln.supportsDestName = function(app, platform){
 
 /**
  *
- * @param {mixed} destination (required) - destination location to use for navigation - see launchnavigator.navigate()
- * @param {object} options (optional) - optional parameters - see launchnavigator.navigate()
+ * @param {string/number[]} destination (required) - destination location to use for navigation - see launchnavigator.navigate()
+ * @param {object} [options={}] - optional parameters - see launchnavigator.navigate()
+ * @param {function} successCallback - function executed in case of success
+ * @param {function} errorCallback - function executed in case of error
  */
 ln.userSelect = function(destination, options, successCallback, errorCallback){
     var userSelectDisplayed, app;
@@ -506,7 +508,7 @@ ln.userSelect = function(destination, options, successCallback, errorCallback){
         userSelectDisplayed = false;
         var idx = btnNumber - 1;
         app = buttonMap[idx];
-        if(app != "cancel"){
+        if(app !== "cancel"){
             options.appSelection.callback(app);
             if(options.appSelection.rememberChoice.enabled === true || options.appSelection.rememberChoice.enabled === "true"){
                 rememberUserChoiceAndLaunch();
@@ -601,11 +603,11 @@ ln.userSelect = function(destination, options, successCallback, errorCallback){
             buttonMap[buttonList.length-1] = _app;
         }
 
-        if(buttonList.length == 0){
+        if(buttonList.length === 0){
             return options.errorCallback('No apps in selection list are available');
         }
 
-        if(buttonList.length == 1){
+        if(buttonList.length === 1){
             app = buttonMap[0];
             return launchApp();
         }
@@ -628,7 +630,7 @@ ln.appSelection = {
 
 /**
  * Indicates whether a user choice exists for a preferred navigator app.
- * @param [function} cb - function to pass result to: will receive a boolean argument.
+ * @param {function} cb - function to pass result to: will receive a boolean argument.
  */
 ln.appSelection.userChoice.exists = function(cb){
     itemExists("choice", cb);
@@ -636,7 +638,7 @@ ln.appSelection.userChoice.exists = function(cb){
 
 /**
  * Returns current user choice of preferred navigator app.
- * @param [function} cb - function to pass result to: will receive a string argument indicating the app, which is a constant in `launchnavigator.APP`.
+ * @param {function} cb - function to pass result to: will receive a string argument indicating the app, which is a constant in `launchnavigator.APP`.
  * If no current choice exists, value will be null.
  */
 ln.appSelection.userChoice.get = function(cb){
@@ -646,7 +648,7 @@ ln.appSelection.userChoice.get = function(cb){
 /**
  * Sets the current user choice of preferred navigator app.
  * @param {string} app - app to set as preferred choice as a constant in `launchnavigator.APP`.
- * @param [function} cb - function to call once operation is complete.
+ * @param {function} cb - function to call once operation is complete.
  */
 ln.appSelection.userChoice.set = function(app, cb){
     setItem("choice", app, cb);
@@ -654,7 +656,7 @@ ln.appSelection.userChoice.set = function(app, cb){
 
 /**
  * Clears current user choice of preferred navigator app.
- * @param [function} cb - function to call once operation is complete.
+ * @param {function} cb - function to call once operation is complete.
  */
 ln.appSelection.userChoice.clear = function(cb){
     removeItem("choice", cb);
@@ -662,7 +664,7 @@ ln.appSelection.userChoice.clear = function(cb){
 
 /**
  * Indicates whether user has already been prompted whether to remember their choice a preferred navigator app.
- * @param [function} cb - function to pass result to: will receive a boolean argument.
+ * @param {function} cb - function to pass result to: will receive a boolean argument.
  */
 ln.appSelection.userPrompted.get = function(cb){
     itemExists("prompted", cb);
@@ -670,7 +672,7 @@ ln.appSelection.userPrompted.get = function(cb){
 
 /**
  * Sets flag indicating user has already been prompted whether to remember their choice a preferred navigator app.
- * @param [function} cb - function to call once operation is complete.
+ * @param {function} cb - function to call once operation is complete.
  */
 ln.appSelection.userPrompted.set = function(cb){
     setItem("prompted", true, cb);
@@ -678,7 +680,7 @@ ln.appSelection.userPrompted.set = function(cb){
 
 /**
  * Clears flag which indicates if user has already been prompted whether to remember their choice a preferred navigator app.
- * @param [function} cb - function to call once operation is complete.
+ * @param {function} cb - function to call once operation is complete.
  */
 ln.appSelection.userPrompted.clear = function(cb){
     removeItem("prompted", cb);
@@ -725,7 +727,7 @@ ln.util.countKeysInObject = function (o){
 };
 
 ln.util.isValidApp = function(app){
-    if(app == "none") return true; // native chooser
+    if(app === "none") return true; // native chooser
     return ln.util.objectContainsValue(ln.APP, app);
 };
 
@@ -756,7 +758,7 @@ ln.util.validateTransportMode = function(transportMode){
 };
 
 ln.util.extractCoordsFromLocationString = function(location){
-    if(location && typeof(location) == "string" && location.match(ln.COORDS_REGEX)){
+    if(location && typeof(location) === "string" && location.match(ln.COORDS_REGEX)){
         location = location.replace(/\s*/g,'');
         var parts = location.split(",");
         location = [parts[0], parts[1]];
@@ -766,7 +768,7 @@ ln.util.extractCoordsFromLocationString = function(location){
 
 ln.util.isValidLaunchMode = function(launchMode){
     for(var LAUNCH_MODE in ln.LAUNCH_MODE){
-        if(launchMode == ln.LAUNCH_MODE[LAUNCH_MODE]) return true;
+        if(launchMode === ln.LAUNCH_MODE[LAUNCH_MODE]) return true;
     }
     return false;
 };

--- a/www/ios/launchnavigator.js
+++ b/www/ios/launchnavigator.js
@@ -58,7 +58,7 @@ ln.availableApps = function(success, error){
  * Opens navigator app to navigate to given destination, specified by either place name or lat/lon.
  * If a start location is not also specified, current location will be used for the start.
  *
- * @param {mixed} destination (required) - destination location to use for navigation.
+ * @param {string/number[]} destination (required) - destination location to use for navigation.
  * Either:
  * - a {string} containing the address. e.g. "Buckingham Palace, London"
  * - an {array}, where the first element is the latitude and the second element is a longitude, as decimal numbers. e.g. [50.1, -4.0]
@@ -110,7 +110,7 @@ ln.navigate = function(destination, options) {
     options.app = options.app || common.APP.USER_SELECT;
 
     // If app is user-selection
-    if(options.app == common.APP.USER_SELECT){
+    if(options.app === common.APP.USER_SELECT){
         // Invoke user-selection UI and return (as it will re-invoke this method)
         return common.userSelect(destination, options);
     }
@@ -130,7 +130,7 @@ ln.navigate = function(destination, options) {
     };
 
     if(!destination){
-        throwError("No destination was specified");;
+        throwError("No destination was specified");
     }
 
     if(options.extras && typeof  options.extras !== "object"){
@@ -143,7 +143,7 @@ ln.navigate = function(destination, options) {
 
     // Process options
     destination = common.util.extractCoordsFromLocationString(destination);
-    if(typeof(destination) == "object"){
+    if(typeof(destination) === "object"){
         destination = destination.join(",");
         options.destType = "coords";
     }else{
@@ -153,7 +153,7 @@ ln.navigate = function(destination, options) {
     options.start = common.util.extractCoordsFromLocationString(options.start);
     if(!options.start){
         options.startType = "none";
-    }else if(typeof(options.start) == "object"){
+    }else if(typeof(options.start) === "object"){
         options.start = options.start.join(",");
         options.startType = "coords";
     }else{
@@ -191,7 +191,7 @@ ln.navigate = function(destination, options) {
 ln.supportsDestName = function(app, platform, launchMode){
     common.util.validateApp(app);
     common.util.validatePlatform(platform);
-    if(launchMode && platform == common.PLATFORM.IOS && app == common.APP.APPLE_MAPS){
+    if(launchMode && platform === common.PLATFORM.IOS && app === common.APP.APPLE_MAPS){
         common.util.validateLaunchMode(launchMode);
         result = launchMode === ln.LAUNCH_MODE.MAPKIT;
     }else{
@@ -212,7 +212,7 @@ common._supportsDestName = common.supportsDestName;
 ln.supportsStartName = function(app, platform, launchMode){
     common.util.validateApp(app);
     common.util.validatePlatform(platform);
-    if(launchMode && platform == common.PLATFORM.IOS && app == common.APP.APPLE_MAPS){
+    if(launchMode && platform === common.PLATFORM.IOS && app === common.APP.APPLE_MAPS){
         common.util.validateLaunchMode(launchMode);
         result = launchMode === ln.LAUNCH_MODE.MAPKIT;
     }else{

--- a/www/windows/launchnavigator.js
+++ b/www/windows/launchnavigator.js
@@ -57,7 +57,7 @@ ln.availableApps = function(success, error){
  * Opens navigator app to navigate to given destination, specified by either place name or lat/lon.
  * If a start location is not also specified, current location will be used for the start.
  *
- * @param {mixed} destination (required) - destination location to use for navigation.
+ * @param {string/number[]} destination (required) - destination location to use for navigation.
  * Either:
  * - a {string} containing the address. e.g. "Buckingham Palace, London"
  * - an {array}, where the first element is the latitude and the second element is a longitude, as decimal numbers. e.g. [50.1, -4.0]
@@ -112,9 +112,9 @@ ln.navigate = function(destination, options) {
         url += "~";
         destination = common.util.extractCoordsFromLocationString(destination);
         msg += " to ";
-        if(typeof(destination) == "object"){
+        if(typeof(destination) === "object"){
             url += "pos." + destination[0] + "_" + destination[1];
-            msg += destination[0],destination[1];
+            msg += destination[0] + ',' + destination[1];
             if(options.destinationName){
                 url += "_" + options.destinationName;
                 msg += " (" + options.destinationName + ")";
@@ -146,9 +146,9 @@ ln.navigate = function(destination, options) {
     msg += " from ";
     if(options.start){
         options.start = common.util.extractCoordsFromLocationString(options.start);
-        if(typeof(options.start) == "object"){
+        if(typeof(options.start) === "object"){
             url += "pos." + options.start[0] + "_" + options.start[1];
-            msg += options.start[0],options.start[1];
+            msg += options.start[0] + ',' + options.start[1];
             if(options.startName){
                 url += "_" + options.startName;
                 msg += " (" + options.startName + ")";

--- a/www/wp8/launchnavigator.js
+++ b/www/wp8/launchnavigator.js
@@ -57,7 +57,7 @@ ln.availableApps = function(success, error){
  * Opens navigator app to navigate to given destination, specified by either place name or lat/lon.
  * If a start location is not also specified, current location will be used for the start.
  *
- * @param {mixed} destination (required) - destination location to use for navigation.
+ * @param {string/number[]} destination (required) - destination location to use for navigation.
  * Either:
  * - a {string} containing the address. e.g. "Buckingham Palace, London"
  * - an {array}, where the first element is the latitude and the second element is a longitude, as decimal numbers. e.g. [50.1, -4.0]
@@ -112,9 +112,9 @@ ln.navigate = function(destination, options) {
         url += "~";
         destination = common.util.extractCoordsFromLocationString(destination);
         msg += " to ";
-        if(typeof(destination) == "object"){
+        if(typeof(destination) === "object"){
             url += "pos." + destination[0] + "_" + destination[1];
-            msg += destination[0],destination[1];
+            msg += destination[0] + ',' + destination[1];
             if(options.destinationName){
                 url += "_" + options.destinationName;
                 msg += " (" + options.destinationName + ")";
@@ -146,9 +146,9 @@ ln.navigate = function(destination, options) {
     msg += " from ";
     if(options.start){
         options.start = common.util.extractCoordsFromLocationString(options.start);
-        if(typeof(options.start) == "object"){
+        if(typeof(options.start) === "object"){
             url += "pos." + options.start[0] + "_" + options.start[1];
-            msg += options.start[0],options.start[1];
+            msg += options.start[0] + ',' + options.start[1];
             if(options.startName){
                 url += "_" + options.startName;
                 msg += " (" + options.startName + ")";


### PR DESCRIPTION
launchnavigator:
- jsdoc: navigate() using more descriptive param type than mixed
- comparison of string values with type safety
- typeof(x) always returns a string value, so also use type safe check

windows.launchnavigator:
- fixed log message where only on of the coordinates is added to the message text

common:
- jsdoc: fixed some param descriptions
- type safe comparison