### PR TITLE
Add ability to specify location of the ActionSheet on iPad

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,10 @@ Either:
             - Defaults to "Select app for navigation" if not specified.
         - {string} cancelButtonText - text to display for the cancel button.
             - Defaults to "Cancel" if not specified.
+        - {number} dialogPositionX - [iPad only] x position for the dialog
+            - Defaults to 550 if not specified
+        - {number} dialogPositionY - [iPad only] y position for the dialog
+            - Defaults to 500 if not specified
         - {array} list - list of apps, defined as `launchnavigator.APP` constants, which should be displayed in the picker if the app is available.
         This can be used to restrict which apps are displayed, even if they are installed. By default, all available apps will be displayed.
         - {function} callback - a callback to invoke when the user selects an app in the native picker.

--- a/www/common.js
+++ b/www/common.js
@@ -486,6 +486,8 @@ ln.userSelect = function(destination, options, successCallback, errorCallback){
     
     // app selection
     options.appSelection = options.appSelection || {};
+    options.appSelection.dialogPositionX = options.appSelection.dialogPositionX || 550;
+    options.appSelection.dialogPositionY = options.appSelection.dialogPositionY || 500;
     options.appSelection.callback = options.appSelection.callback || emptyFn;
     options.appSelection.rememberChoice = options.appSelection.rememberChoice || {};
     options.appSelection.rememberChoice.enabled = typeof options.appSelection.rememberChoice.enabled !== "undefined" ? options.appSelection.rememberChoice.enabled : "prompt";
@@ -510,7 +512,7 @@ ln.userSelect = function(destination, options, successCallback, errorCallback){
             'androidEnableCancelButton' : true, // default false
             //'winphoneEnableCancelButton' : true, // default false
             'addCancelButtonWithLabel': options.appSelection.cancelButtonText || DEFAULT_appSelectionCancelButtonText,
-            'position': [550, 500] // for iPad pass in the [x, y] position of the popover
+            'position': [options.appSelection.dialogPositionX, options.appSelection.dialogPositionY] // for iPad pass in the [x, y] position of the popover
         }, onChooseApp);
     };
 


### PR DESCRIPTION
In the current implementation the ActionSheet on iPad is centered in the screen. It would be useful to be able to specify the location to improve the UI.

![picker](https://user-images.githubusercontent.com/1243453/32457780-140370b0-c2df-11e7-87ca-485bd82fd814.png)
