### PR TITLE
Compile on older versions of XCode

### DIFF
--- a/src/ios/LaunchNavigator.m
+++ b/src/ios/LaunchNavigator.m
@@ -312,7 +312,7 @@ NSDictionary* extras;
     }
     
     if(!destAddress){
-        MKPlacemark* placemark = [[MKPlacemark alloc] initWithCoordinate:destCoord];
+        MKPlacemark* placemark = [[MKPlacemark alloc] initWithCoordinate:destCoord addressDictionary:nil];
         dest_mapItem = [[MKMapItem alloc] initWithPlacemark:placemark];
         if(destName){
             [dest_mapItem setName:destName];
@@ -323,7 +323,7 @@ NSDictionary* extras;
         [MKMapItem openMapsWithItems:@[dest_mapItem] launchOptions:launchOptions];
     }else{
         if(!startAddress){
-            start_mapItem = [[MKMapItem alloc] initWithPlacemark:[[MKPlacemark alloc] initWithCoordinate:startCoord]];
+            start_mapItem = [[MKMapItem alloc] initWithPlacemark:[[MKPlacemark alloc] initWithCoordinate:startCoord addressDictionary:nil]];
             if(startName){
                 [start_mapItem setName:startName];
             }


### PR DESCRIPTION
I'm on OSX Yosemite, XCode 7.0,1, and required these explicit args
  

Compile error on these lines:

<img width="1385" alt="screen shot 2018-01-03 at 11 22 09 am" src="https://user-images.githubusercontent.com/142914/34531583-67bda164-f078-11e7-90c8-6de427f72470.png">
