### PR TITLE
Trying to fix a build error on XCode 8.3.2 targeting iOS 9.x.

### DIFF
--- a/src/ios/LaunchNavigator.m
+++ b/src/ios/LaunchNavigator.m
@@ -1533,15 +1533,21 @@ NSDictionary* extras;
   UIApplication *application = [UIApplication sharedApplication];
   NSURL *URL = [NSURL URLWithString:scheme];
 
-  if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
-    [application openURL:URL options:@{}
-       completionHandler:^(BOOL success) {
-       [self onOpenSchemeResult:scheme schemeResult:success];
-    }];
-  } else {
-    BOOL success = [application openURL:URL];
-    [self onOpenSchemeResult:scheme schemeResult:success];
-  }
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_10_0
+      if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+        [application openURL:URL options:@{}
+           completionHandler:^(BOOL success) {
+           [self onOpenSchemeResult:scheme schemeResult:success];
+        }];
+      } else {
+        BOOL success = [application openURL:URL];
+        [self onOpenSchemeResult:scheme schemeResult:success];
+      }
+    #else
+        BOOL success = [application openURL:URL];
+        [self onOpenSchemeResult:scheme schemeResult:success];
+    #endif
+    
 }
 
 - (void)onOpenSchemeResult:(NSString *)scheme schemeResult:(BOOL)success


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [ ] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

Using this plugin if you're compiling with older versions of xcode targeting older iOS versions your compile will fail with an error message like: /Plugins/uk.co.workingedge.phonegap.plugin.launchnavigator/LaunchNavigator.m:1537:18: no visible @interface for 'UIApplication' declares the selector 'openURL:options:completionHandler:'
 [application openURL:URL options:@{}

## Does this PR introduce a breaking change?
- [ ] Yes
- [ X] No

## Other information
Opening this PR to get feedback on the change, not very elegant but appears it may solve the compiling issue. CI testing is limited due to not being able to pull it from the registry. The issue seems to be the selector surface for openURL.