### PR TITLE
Update README.md for setting a blank GOOGLE_API_KEY_FOR_ANDROID

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ This plugin is intended to launch **native** navigation apps and therefore will 
     $ phonegap plugin add uk.co.workingedge.phonegap.plugin.launchnavigator --variable GOOGLE_API_KEY_FOR_ANDROID="{your_api_key}"
     $ ionic cordova plugin add uk.co.workingedge.phonegap.plugin.launchnavigator --variable GOOGLE_API_KEY_FOR_ANDROID="{your_api_key}"
 
+**Note:** `GOOGLE_API_KEY_FOR_ANDROID=""` is safe to use if navigation is only being performed with latitude/longitude coordinates.
+
 ## PhoneGap Build
 
 Add the following xml to your config.xml to use the latest version of this plugin from [npm](https://www.npmjs.com/package/uk.co.workingedge.phonegap.plugin.launchnavigator):
@@ -238,12 +240,13 @@ Add the following xml to your config.xml to use the latest version of this plugi
 - Google now requires that an API key be specified in order to use the Geocoding API
     - For more information on how to obtain an API key, see the [Google documentation](https://developers.google.com/maps/documentation/geocoding/get-api-key).
     - Don't place any application restrictions on the key, otherwise geocoding will fail.
-- You'll need to provide your Google API key to the plugin by either:
+- You can provide your Google API key to the plugin by either:
     - setting the `GOOGLE_API_KEY_FOR_ANDROID` plugin variable during plugin installation
         - Note: this method places your API in the `AndroidManifest.xml` in cleartext so carries the possible security risk of a malicious party decompiling your app to obtain your API key (see [#249](https://github.com/dpa99c/phonegap-launch-navigator/issues/249))
     - setting it at runtime by calling the [setApiKey()](#setapikey) function
         - this method is secure from a security perspective.
         - you must call this method in each app session (e.g. at app startup) before attempting to use the plugin's geocoding features on Android.
+- If you are only navigating via latitude/longitude coordinates and therefore not using Google's Geocoding API, **you can safely set the API Key to an empty string**.
 
 ## OKHTTP Library
 - This plugin uses the [OKHTTP library](https://square.github.io/okhttp/) on Android to access Google's remote Geocoding API service


### PR DESCRIPTION
Added documentation for providing an empty GOOGLE_API_KEY_FOR_ANDROID.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [ ] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->
Pertaining to this issue: https://github.com/dpa99c/phonegap-launch-navigator/issues/222#issuecomment-469599605

It was mentioned that the `GOOGLE_API_KEY_FOR_ANDROID` can be set to an empty string (`""`) if the user does not intend to use the Geocoding API. The plugin gives an error if you omit this variable during installation, so it's non-obvious that it is safe to set this to an empty string.

Since this is a potentially common use-case, I've added to the installation and Google API Key docs explaining this is possible, and what the effects of doing so are (namely that you can't use the Geocoding API, and must use latitude/longitude coordinates with the plugin).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->
Ocular inspection. :eyes: 

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->
None (only documentation updates).
